### PR TITLE
add a passwd policy generation script

### DIFF
--- a/provision/tpm-policy.passwd.sh
+++ b/provision/tpm-policy.passwd.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+####
+# config
+
+# /dev/random for easier dev, /dev/hwrng for fips-140 compliance
+RNG_SOURCE="/dev/random"
+
+TPM_POL_PUBKEY_ALG="rsa"
+TPM_POL_VERSION="0x00000001"
+
+TPM_PCRS_DEF="sha256:7"
+
+# dev/test nvindex values
+TPM_NV_VERSION="0x1500020"
+
+####
+# functions
+
+function notice() {
+	echo ">>> notice: $@"
+}
+
+function warn() {
+	echo ">>> warning: $@"
+}
+
+function error() {
+	echo ">>> error: $@"
+	exit 1
+}
+
+function error_check() {
+	[[ $1 -eq 0 ]] && return
+	shift
+	error "$@"
+}
+
+function usage() {
+	echo "usage: $0 <pcrs_passwd.bin>"
+	echo "  all pcr files should contain only $TPM_PCRS_DEF values"
+	exit 1
+}
+
+####
+# main
+
+#
+# arg processing
+
+[[ $# -eq 1 ]] || usage
+pcrs_passwd=$1
+[[ -r $pcrs_passwd ]] || \
+	error "unable to read the TPM administrative pcr values ($pcrs_passwd)"
+
+#
+# create some scratch space
+
+tdir=$(mktemp -d -t tpm-XXXXXXXX)
+trap '(rm -rf $tdir)' EXIT
+
+#
+# nvindex for the TPM administrative password
+
+# NOTE: this policy file must be signed afterwards
+pol_passwd="./tpm_passwd.policy"
+
+notice "creating TPM_NV_PASSWD policy"
+
+tpm2_createprimary -C p -c $tdir/tpm_ctx_b
+tpm2_startauthsession -S $tdir/tpm_session_b -c $tdir/tpm_ctx_b
+tpm2_policypcr -S $tdir/tpm_session_b -l $TPM_PCRS_DEF -f $pcrs_passwd \
+    -L $pol_passwd
+tpm2_flushcontext $tdir/tpm_session_b
+
+# cleanup
+rm -f $tdir/tpm_ctx_b $tdir/tpm_session_b
+
+#
+# done
+
+notice "policy PASSWD($pol_passwd)"
+exit 0


### PR DESCRIPTION
This is analogous to the tpm-policy.sh.  tpm-policy.sh gives the
policy hash for the 'secret' nvindex EA policy.  tpm-policy.passwd.sh
gives it for the 'TPM administrative password" EA policy, since it
also needs to be signed.

Point is we don't want to have to fully provision a TPM using
tpm-setup.sh to generate these files to sign them.

Signed-off-by: Serge Hallyn <serge@hallyn.com>