### PR TITLE
Clarify that two pubkeys must be used

### DIFF
--- a/provision/tpm-policy.passwd.sh
+++ b/provision/tpm-policy.passwd.sh
@@ -62,7 +62,8 @@ trap '(rm -rf $tdir)' EXIT
 #
 # nvindex for the TPM administrative password
 
-# NOTE: this policy file must be signed afterwards
+# NOTE: this policy file must be signed afterwards using the
+# password-policy signing pubkey
 pol_passwd="./tpm_passwd.policy"
 
 notice "creating TPM_NV_PASSWD policy"

--- a/provision/tpm-policy.sh
+++ b/provision/tpm-policy.sh
@@ -62,7 +62,8 @@ trap '(rm -rf $tdir)' EXIT
 #
 # nvindex for the secret
 
-# NOTE: this policy file must be signed afterwards
+# NOTE: this policy file must be signed afterwards using the
+# secret-policy signing pubkey
 pol_secret="./tpm_secret.policy"
 
 notice "creating TPM_NV_SECRET policy"

--- a/read/tpm-read-passwd.sh
+++ b/read/tpm-read-passwd.sh
@@ -70,7 +70,7 @@ trap '(rm -rf $tdir)' EXIT
 #
 # load the public signing key into the tpm
 
-notice "loading tpm ea policy public key"
+notice "loading password-reading tpm ea policy public key"
 tpm2_loadexternal -C o -G $TPM_POL_PUBKEY_ALG -u $pubkey_file \
 	-c $tdir/pubkey_ctx_a -n $tdir/pubkey_name_a
 error_check $? "unable to load the public signing key($pubkey_file)"

--- a/read/tpm-read-secret.sh
+++ b/read/tpm-read-secret.sh
@@ -71,7 +71,7 @@ trap '(rm -rf $tdir)' EXIT
 #
 # load the public signing key into the tpm
 
-notice "loading tpm ea policy public key"
+notice "loading secret-reading tpm ea policy public key"
 tpm2_loadexternal -C o -G $TPM_POL_PUBKEY_ALG -u $pubkey_file \
 	-c $tdir/pubkey_ctx_a -n $tdir/pubkey_name_a
 error_check $? "unable to load the public signing key($pubkey_file)"


### PR DESCRIPTION
Using the same public key for the tpm admin password and luks key would be detrimental.  Make that clearer in comments in the scripts.

Signed-off-by: Serge Hallyn <serge@hallyn.com>